### PR TITLE
Convert string literals to constants

### DIFF
--- a/include/messages/kan/boot.h
+++ b/include/messages/kan/boot.h
@@ -1,0 +1,29 @@
+/* BSD Zero Clause License */
+
+/* Copyright (C) 2022 mintsuki and contributors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _MSG_BOOT_H
+#define _MSG_BOOT_H 1
+
+#define UNKNOWN_NAME "unknown"
+#define BOOT_CONSOLE_NAME "boot_console"
+
+#define RECLAIMED_KIB_MSG "boot_info: reclaimed %zu KiB"
+#define BOOT_INFO_VERSION_MSG "boot_info: %s %s"
+#define NO_HHDM_RESPONSE_MSG "boot_info: no hhdm_response"
+#define NO_KERNEL_ADDRESS_RESPONSE_MSG "boot_info: no kernel_address_response"
+#define NO_MEMMAP_RESPONSE_MSG "boot_info: no memmap_response"
+
+#endif

--- a/src/kan/boot.c
+++ b/src/kan/boot.c
@@ -9,6 +9,7 @@
 #include <kan/symbol.h>
 #include <stddef.h>
 #include <string.h>
+#include <messages/kan/boot.h>
 
 static volatile struct limine_bootloader_info_request info_request = {
     .id = LIMINE_BOOTLOADER_INFO_REQUEST,
@@ -68,7 +69,7 @@ static void boot_console_puts(console_t *restrict con, const char *restrict s)
 }
 
 static console_t boot_console = {
-    .name = "boot_console",
+    .name = BOOT_CONSOLE_NAME,
     .puts_fn = &boot_console_puts,
     .next = NULL,
 };
@@ -122,7 +123,7 @@ void reclaim_bootloader_memory(void)
         }
     }
 
-    pr_inform("boot_info: reclaimed %zu KiB", fsize);
+    pr_inform(RECLAIMED_KIB_MSG, fsize);
 }
 
 void unregister_boot_console(void)
@@ -150,15 +151,15 @@ static int init_boot_info(void)
         version = info_request.response->version;
     }
     else {
-        name = "unknown";
+        name = UNKNOWN_NAME;
         version = "0.0.0";
     }
 
-    pr_inform("boot_info: %s %s", name, version);
+    pr_inform(BOOT_INFO_VERSION_MSG, name, version);
 
-    panic_if(!hhdm_request.response, "boot_info: no hhdm_response");
-    panic_if(!kernel_address_request.response, "boot_info: no kernel_address_response");
-    panic_if(!memmap_request.response, "boot_info: no memmap_response");
+    panic_if(!hhdm_request.response, NO_HHDM_RESPONSE_MSG);
+    panic_if(!kernel_address_request.response, NO_KERNEL_ADDRESS_RESPONSE_MSG);
+    panic_if(!memmap_request.response, NO_MEMMAP_RESPONSE_MSG);
 
     hhdm_offset = hhdm_request.response->offset;
     kernel_address_phys = kernel_address_request.response->physical_base;


### PR DESCRIPTION
Not yet complete, but this PR just replaces all string literals within `src/kan/boot.c` with constants that are defined within
`include/messages/kan/boot.h`.
Ideally, eventually all string literals would be replaced with constants, in order to help maintain extensibility and keeping the project
easy to modify. If this PR is approved, I will continue to replace string literals with constants