### PR TITLE
Add `\n!~ KERNEL PANIC ~!\n` message to kernel panic code

### DIFF
--- a/kern/panic.c
+++ b/kern/panic.c
@@ -25,6 +25,7 @@ void __noreturn fvpanic(const char *restrict file, long line, const char *restri
         it->unblank(it);
     }
 
+    kvlog(LOG_EMERG, "\n!~ KERNEL PANIC ~!\n", ap);
     klog(LOG_EMERG, "panic at [%s:%ld]", file, line);
     kvlog(LOG_EMERG, fmt, ap);
 

--- a/kern/panic.c
+++ b/kern/panic.c
@@ -25,7 +25,7 @@ void __noreturn fvpanic(const char *restrict file, long line, const char *restri
         it->unblank(it);
     }
 
-    kvlog(LOG_EMERG, "\n!~ KERNEL PANIC ~!\n", ap);
+    kvlog(LOG_EMERG, "\n!~ KERNEL PANIC ~!\n");
     klog(LOG_EMERG, "panic at [%s:%ld]", file, line);
     kvlog(LOG_EMERG, fmt, ap);
 


### PR DESCRIPTION
This makes it easier to see that there is a kernel panic without reading every line of output